### PR TITLE
ci: GitHub Actions 보안 취약점 수정 (zizmor)

### DIFF
--- a/.github/workflows/codegen.yml
+++ b/.github/workflows/codegen.yml
@@ -14,8 +14,10 @@ jobs:
       run:
         working-directory: ./codegen
     steps:
-      - uses: actions/checkout@v5
-      - uses: denoland/setup-deno@v1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          persist-credentials: false
+      - uses: denoland/setup-deno@11b63cf76cfcafb4e43f97b6cad24d8e8438f62d # v1.5.2
         with:
           deno-version: v1.x
       - run: deno fmt --check

--- a/.github/workflows/javascript.yml
+++ b/.github/workflows/javascript.yml
@@ -20,13 +20,15 @@ jobs:
         working-directory: ./javascript
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          persist-credentials: false
       - name: Setup pnpm
         uses: pnpm/action-setup@26f6d4f2c533a43e6b5da0b4a5dd983f98f7b49a
         with:
           package_json_file: ./javascript/package.json
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 25
           cache: pnpm
@@ -36,7 +38,7 @@ jobs:
       - name: Run typedoc
         run: pnpm typedoc
       - name: Deploy on GitHub Pages
-        uses: peaceiris/actions-gh-pages@v4
+        uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4.1.0
         with:
           deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
           publish_dir: ./javascript/docs
@@ -50,13 +52,15 @@ jobs:
         working-directory: ./javascript
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          persist-credentials: false
       - name: Setup pnpm
         uses: pnpm/action-setup@26f6d4f2c533a43e6b5da0b4a5dd983f98f7b49a
         with:
           package_json_file: ./javascript/package.json
       - name: Setup Node.js 20.x
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 20
           cache: pnpm
@@ -74,15 +78,16 @@ jobs:
         working-directory: ./javascript
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Setup pnpm
         uses: pnpm/action-setup@26f6d4f2c533a43e6b5da0b4a5dd983f98f7b49a
         with:
           package_json_file: ./javascript/package.json
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 25
           cache: pnpm
@@ -110,7 +115,9 @@ jobs:
       id-token: write
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          persist-credentials: false
 
       - name: Setup pnpm
         uses: pnpm/action-setup@26f6d4f2c533a43e6b5da0b4a5dd983f98f7b49a
@@ -118,7 +125,7 @@ jobs:
           package_json_file: ./javascript/package.json
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           # provenance requires node>=24
           node-version: 25

--- a/.github/workflows/jvm.yml
+++ b/.github/workflows/jvm.yml
@@ -17,9 +17,10 @@ jobs:
         working-directory: ./jvm
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Build
         run: ./gradlew build
         env:
@@ -34,13 +35,14 @@ jobs:
         working-directory: ./jvm
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Run dokka
         run: ./gradlew dokkaGenerateHtml
       - name: Deploy on GitHub Pages
-        uses: peaceiris/actions-gh-pages@v4
+        uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4.1.0
         with:
           deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
           publish_dir: ./jvm/lib/build/dokka/html
@@ -58,7 +60,9 @@ jobs:
       url: https://central.sonatype.com/artifact/io.portone/server-sdk
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          persist-credentials: false
       - name: Publish package
         run: ./gradlew publishAndReleaseToMavenCentral --no-configuration-cache
         env:
@@ -69,7 +73,7 @@ jobs:
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGINMEMORYKEYPASSWORD }}
       - name: Send a Slack notification if a publish happens
         run: |
-          export VERSION=$(cut -c '16-' <<< '${{ github.ref }}')
+          export VERSION=$(cut -c '16-' <<< '${GITHUB_REF}')
           curl -X POST -H 'Content-type: application/json'\
             --data '{"blocks":[{"type":"section","text":{"type":"mrkdwn","text":"Maven Central에 `io.portone:server-sdk` 버전 *v'"$VERSION"'* 가 배포되었습니다 :rocket:"}},{"type":"actions","elements":[{"type":"button","text":{"type":"plain_text","text":"Maven 페이지 보기"},"value":"show_maven_page","url":"https://central.sonatype.com/artifact/io.portone/server-sdk/'"$VERSION"'","action_id":"show_maven_page"}]}]}'\
             ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -20,12 +20,14 @@ jobs:
         working-directory: ./python
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v5
-      - uses: actions/setup-python@v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4.9.1
         with:
           python-version: "3.9"
       - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39 # v3.2.4
         with:
           version: "latest"
           enable-cache: true
@@ -35,7 +37,7 @@ jobs:
         run: uv run make html
         working-directory: ./python/docs
       - name: Deploy on GitHub Pages
-        uses: peaceiris/actions-gh-pages@v4
+        uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4.1.0
         with:
           deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
           publish_dir: ./python/docs/_build/html
@@ -49,12 +51,14 @@ jobs:
         working-directory: ./python
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v5
-      - uses: actions/setup-python@v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4.9.1
         with:
           python-version: "3.9"
       - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39 # v3.2.4
         with:
           version: "latest"
           enable-cache: true
@@ -71,12 +75,14 @@ jobs:
         working-directory: ./python
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v5
-      - uses: actions/setup-python@v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4.9.1
         with:
           python-version: "3.9"
       - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39 # v3.2.4
         with:
           version: "latest"
           enable-cache: true
@@ -101,12 +107,14 @@ jobs:
         working-directory: ./python
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v5
-      - uses: actions/setup-python@v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4.9.1
         with:
           python-version: "3.9"
       - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39 # v3.2.4
         with:
           version: "latest"
           enable-cache: true
@@ -120,7 +128,7 @@ jobs:
         run: uv publish
       - name: Send a Slack notification if a publish happens
         run: |
-          export VERSION=$(cut -c '15-' <<< '${{ github.ref }}')
+          export VERSION=$(cut -c '15-' <<< '${GITHUB_REF}')
           curl -X POST -H 'Content-type: application/json'\
             --data '{"blocks":[{"type":"section","text":{"type":"mrkdwn","text":"PyPI에 `portone-server-sdk` 버전 *v'"$VERSION"'* 가 배포되었습니다 :rocket:"}},{"type":"actions","elements":[{"type":"button","text":{"type":"plain_text","text":"PyPI 페이지 보기"},"value":"show_pypi_page","url":"https://pypi.org/project/portone-server-sdk/'"$VERSION"'","action_id":"show_pypi_page"}]}]}'\
             ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
## 개요

[zizmor](https://github.com/woodruffw/zizmor)로 GitHub Actions 워크플로우 보안 감사를 수행하고 자동 수정 가능한 항목을 적용했습니다.

## 수정 내용

- **unpinned-uses**: 액션 참조를 버전 태그에서 전체 커밋 SHA로 고정 (`actions/checkout`, `actions/setup-node`, `actions/setup-python`, `denoland/setup-deno`, `astral-sh/setup-uv`, `peaceiris/actions-gh-pages`)
- **artipacked**: `actions/checkout` 스텝에 `persist-credentials: false` 추가
- **template-injection**: `${{ github.ref }}` 를 `${GITHUB_REF}` 환경변수 참조로 대체