### PR TITLE
fix(python): normalize webhook header lookup

### DIFF
--- a/python/src/portone_server_sdk/webhook.py
+++ b/python/src/portone_server_sdk/webhook.py
@@ -179,14 +179,14 @@ class InvalidInputError(PortOneError):
 
 
 def verify(
-    secret: Union[str, bytes, bytearray], payload: str, headers: Mapping[str, str]
+    secret: Union[str, bytes, bytearray], payload: str, headers: Mapping[str, object]
 ) -> Webhook:
     """웹훅 페이로드를 검증합니다.
 
     Args:
         secret (str | bytes | bytearray): 웹훅 시크릿
         payload (str): 웹훅 페이로드
-        headers (Mapping[str, str]): 웹훅 요청 시 포함된 헤더
+        headers (Mapping[str, object]): 웹훅 요청 시 포함된 헤더
 
     Raises:
         InvalidInputError: 입력받은 시크릿이 유효하지 않을 때 발생합니다.
@@ -195,18 +195,20 @@ def verify(
     Returns:
         검증된 웹훅 페이로드. 웹훅 형식이 올바르지 않을 경우 `None` 입니다.
     """
+    header_values: dict[str, str] = {}
     for header_name in _required_headers:
-        header_value = headers.get(header_name)
-        if not isinstance(header_value, _required_headers[header_name]):
+        header_value = _find_header_value(headers, header_name)
+        if header_value is None:
             raise WebhookVerificationError("MISSING_REQUIRED_HEADERS")
+        header_values[header_name] = header_value
 
-    msg_timestamp = headers["webhook-timestamp"]
+    msg_timestamp = header_values["webhook-timestamp"]
     _verify_timestamp(msg_timestamp)
 
-    msg_id = headers["webhook-id"]
+    msg_id = header_values["webhook-id"]
     expected_signature = _sign(secret, msg_id, msg_timestamp, payload)
 
-    msg_signature = headers["webhook-signature"]
+    msg_signature = header_values["webhook-signature"]
     for versioned_signagure in msg_signature.split(" "):
         split = versioned_signagure.split(",", 3)
         if len(split) < 2:
@@ -222,6 +224,24 @@ def verify(
         if hmac.compare_digest(signature_decoded, expected_signature):
             return _deserialize_webhook(json.loads(payload))
     raise WebhookVerificationError("NO_MATCHING_SIGNATURE")
+
+
+def _find_header_value(headers: Mapping[str, object], name: str) -> Optional[str]:
+    name_lowercase = name.lower()
+    found: Optional[str] = None
+    for key, value in headers.items():
+        if key.lower() != name_lowercase:
+            continue
+        values = value if isinstance(value, list) else [value]
+        for item in values:
+            if item is None:
+                continue
+            if not isinstance(item, str):
+                return None
+            if found is not None:
+                return None
+            found = item
+    return found
 
 
 WEBHOOK_TOLERANCE_IN_SECONDS = 5 * 60  # 5분

--- a/python/tests/test_webhook.py
+++ b/python/tests/test_webhook.py
@@ -5,6 +5,8 @@ import time
 from dataclasses import dataclass
 from typing import Optional
 
+import pytest
+
 import portone_server_sdk as portone
 
 secret = codecs.decode(b"pzQGE83cSIRKM4/WH5QY+g==", "base64")
@@ -63,6 +65,28 @@ def test_verify_valid_signature_recognized():
     test_webhook = make_webhook(test_object_recognized)
     webhook = portone.webhook.verify(secret, test_webhook.payload, test_webhook.headers)
     assert isinstance(webhook, portone.webhook.WebhookTransactionCancelledCancelled)
+
+
+def test_verify_valid_signature_with_case_insensitive_headers():
+    test_webhook = make_webhook(test_object_unrecognized)
+    headers = {
+        "Webhook-Id": test_webhook.headers["webhook-id"],
+        "Webhook-Signature": test_webhook.headers["webhook-signature"],
+        "Webhook-Timestamp": test_webhook.headers["webhook-timestamp"],
+    }
+    webhook = portone.webhook.verify(secret, test_webhook.payload, headers)
+    assert webhook == test_object_unrecognized
+
+
+def test_verify_rejects_duplicate_header_names():
+    test_webhook = make_webhook(test_object_unrecognized)
+    headers = {
+        **test_webhook.headers,
+        "Webhook-Id": test_webhook.headers["webhook-id"],
+    }
+    with pytest.raises(portone.webhook.WebhookVerificationError) as e:
+        portone.webhook.verify(secret, test_webhook.payload, headers)
+    assert e.value.reason == "MISSING_REQUIRED_HEADERS"
 
 
 def test_verify_multiple_signatures():


### PR DESCRIPTION
## Summary

- Resolve Python webhook headers case-insensitively before verification
- Reject duplicate case-variant header names instead of silently choosing one value
- Add webhook tests for mixed-case required headers and duplicate header names

## Verification

- Not run locally. This workspace does not expose a configured PortOne Python test intent, so I did not infer an ad-hoc test command.
