### PR TITLE
fix(python): add client lifecycle methods

### DIFF
--- a/codegen/python/project.ts
+++ b/codegen/python/project.ts
@@ -162,6 +162,7 @@ function generateCategoryIndex(
   if (hasClient) {
     importWriter.writeLine("import httpx")
     importWriter.writeLine("import json")
+    importWriter.writeLine("from types import TracebackType")
     importWriter.writeLine(
       "from httpx import AsyncClient, Client as SyncClient",
     )
@@ -169,6 +170,7 @@ function generateCategoryIndex(
       `from ${toRoot}._user_agent import USER_AGENT`,
     )
     typing.add("Optional")
+    typing.add("Type")
   }
   const errors = pack.operations.map(({ errors }) => errors).toSorted()
   const sortedTyping = [...typing].toSorted()
@@ -361,6 +363,15 @@ function writeClientObject(
     )
   }
   implWriter.outdent()
+  writeClientLifecycleMethods(
+    implWriter,
+    `${toPascalCase(pack.category)}Client`,
+    subpackages,
+    true,
+  )
+  if (pack.operations.length > 0) {
+    implWriter.writeLine("")
+  }
   for (const operation of pack.operations) {
     writeOperation(
       implWriter,
@@ -382,6 +393,73 @@ function writeClientObject(
     )
   }
   implWriter.outdent()
+}
+
+function writeClientLifecycleMethods(
+  writer: Writer,
+  clientName: string,
+  subpackages: Package[],
+  hasHttpClients: boolean,
+) {
+  writer.writeLine("")
+  writer.writeLine("def close(self) -> None:")
+  writer.indent()
+  writer.writeLine(`"""Close the underlying synchronous HTTP client."""`)
+  if (hasHttpClients) {
+    writer.writeLine("self._sync_client.close()")
+  }
+  for (const subpackage of subpackages) {
+    writer.writeLine(`self.${toSnakeCase(subpackage.category)}.close()`)
+  }
+  writer.outdent()
+  writer.writeLine("")
+  writer.writeLine("async def aclose(self) -> None:")
+  writer.indent()
+  writer.writeLine(
+    `"""Close the underlying synchronous and asynchronous HTTP clients."""`,
+  )
+  if (hasHttpClients) {
+    writer.writeLine("self._sync_client.close()")
+    writer.writeLine("await self._async_client.aclose()")
+  }
+  for (const subpackage of subpackages) {
+    writer.writeLine(`await self.${toSnakeCase(subpackage.category)}.aclose()`)
+  }
+  writer.outdent()
+  writer.writeLine("")
+  writer.writeLine(`def __enter__(self) -> "${clientName}":`)
+  writer.indent()
+  writer.writeLine("return self")
+  writer.outdent()
+  writer.writeLine("")
+  writer.writeLine("def __exit__(")
+  writer.indent()
+  writer.writeLine("self,")
+  writer.writeLine("exc_type: Optional[Type[BaseException]],")
+  writer.writeLine("exc_value: Optional[BaseException],")
+  writer.writeLine("traceback: Optional[TracebackType],")
+  writer.outdent()
+  writer.writeLine(") -> None:")
+  writer.indent()
+  writer.writeLine("self.close()")
+  writer.outdent()
+  writer.writeLine("")
+  writer.writeLine(`async def __aenter__(self) -> "${clientName}":`)
+  writer.indent()
+  writer.writeLine("return self")
+  writer.outdent()
+  writer.writeLine("")
+  writer.writeLine("async def __aexit__(")
+  writer.indent()
+  writer.writeLine("self,")
+  writer.writeLine("exc_type: Optional[Type[BaseException]],")
+  writer.writeLine("exc_value: Optional[BaseException],")
+  writer.writeLine("traceback: Optional[TracebackType],")
+  writer.outdent()
+  writer.writeLine(") -> None:")
+  writer.indent()
+  writer.writeLine("await self.aclose()")
+  writer.outdent()
 }
 
 function collectErrors(
@@ -627,7 +705,8 @@ function generateClient(
 ) {
   const writer = PythonWriter()
   writer.writeLine("from __future__ import annotations")
-  writer.writeLine("from typing import Optional")
+  writer.writeLine("from types import TracebackType")
+  writer.writeLine("from typing import Optional, Type")
   for (const subpackage of pack.subpackages) {
     if (isClientPackage(subpackage)) {
       writer.writeLine(
@@ -681,6 +760,7 @@ function writeRootClientObject(
     )
   }
   writer.outdent()
+  writeClientLifecycleMethods(writer, "PortOneClient", subpackages, false)
   writer.outdent()
 }
 

--- a/python/src/portone_server_sdk/_generated/auth/client.py
+++ b/python/src/portone_server_sdk/_generated/auth/client.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 import httpx
 import json
+from types import TracebackType
 from httpx import AsyncClient, Client as SyncClient
 from ..._user_agent import USER_AGENT
-from typing import Optional
+from typing import Optional, Type
 from ..errors import InvalidRequestError, UnauthorizedError, UnknownError
 from ..common.invalid_request_error import _deserialize_invalid_request_error
 from ..common.unauthorized_error import _deserialize_unauthorized_error
@@ -31,6 +32,38 @@ class AuthClient:
         self._store_id = store_id
         self._async_client = AsyncClient(timeout=60.0)
         self._sync_client = SyncClient(timeout=60.0)
+
+    def close(self) -> None:
+        """Close the underlying synchronous HTTP client."""
+        self._sync_client.close()
+
+    async def aclose(self) -> None:
+        """Close the underlying synchronous and asynchronous HTTP clients."""
+        self._sync_client.close()
+        await self._async_client.aclose()
+
+    def __enter__(self) -> "AuthClient":
+        return self
+
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_value: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> None:
+        self.close()
+
+    async def __aenter__(self) -> "AuthClient":
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_value: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> None:
+        await self.aclose()
+
     def login_via_api_secret(
         self,
         *,

--- a/python/src/portone_server_sdk/_generated/b2b/client.py
+++ b/python/src/portone_server_sdk/_generated/b2b/client.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 import httpx
 import json
+from types import TracebackType
 from httpx import AsyncClient, Client as SyncClient
 from ..._user_agent import USER_AGENT
-from typing import Optional
+from typing import Optional, Type
 from urllib.parse import quote
 from .tax_invoice.client import TaxInvoiceClient
 from .counterparty.client import CounterpartyClient
@@ -32,3 +33,38 @@ class B2bClient:
         self._sync_client = SyncClient(timeout=60.0)
         self.tax_invoice = TaxInvoiceClient(secret=secret, base_url=base_url, store_id=store_id)
         self.counterparty = CounterpartyClient(secret=secret, base_url=base_url, store_id=store_id)
+
+    def close(self) -> None:
+        """Close the underlying synchronous HTTP client."""
+        self._sync_client.close()
+        self.tax_invoice.close()
+        self.counterparty.close()
+
+    async def aclose(self) -> None:
+        """Close the underlying synchronous and asynchronous HTTP clients."""
+        self._sync_client.close()
+        await self._async_client.aclose()
+        await self.tax_invoice.aclose()
+        await self.counterparty.aclose()
+
+    def __enter__(self) -> "B2bClient":
+        return self
+
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_value: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> None:
+        self.close()
+
+    async def __aenter__(self) -> "B2bClient":
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_value: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> None:
+        await self.aclose()

--- a/python/src/portone_server_sdk/_generated/b2b/counterparty/client.py
+++ b/python/src/portone_server_sdk/_generated/b2b/counterparty/client.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 import httpx
 import json
+from types import TracebackType
 from httpx import AsyncClient, Client as SyncClient
 from ...._user_agent import USER_AGENT
-from typing import Optional
+from typing import Optional, Type
 from ...errors import B2bCertificateUnregisteredError, B2bCounterpartyBrnInvalidError, B2bCounterpartyBrnModificationNotAllowedError, B2bCounterpartyIdAlreadyExistsByPartnerError, B2bCounterpartyIdAlreadyExistsError, B2bCounterpartyMissingRequiredFieldsError, B2bCounterpartyNotFoundError, B2bCounterpartyNtsConnectionFailedError, B2bCounterpartyNtsNotConnectedError, B2bCounterpartyOngoingTaxInvoiceExistsError, B2bCounterpartyPartnerNotConnectableError, B2bCounterpartyPartnerNotDeletableError, B2bCounterpartyPartnerNotUpdatableError, B2bCounterpartySelfOriginBrnMismatchError, B2bCounterpartyTooManyAdditionalContactsError, B2bCounterpartyVerificationBrnMismatchError, B2bCounterpartyVerificationInvalidError, B2bCounterpartyVerificationNotFoundError, B2bCounterpartyVerificationTypeMismatchError, B2bExternalServiceError, B2bNotEnabledError, ForbiddenError, InvalidRequestError, UnauthorizedError, UnknownError
 from ...b2b.counterparty.b2b_certificate_unregistered_error import _deserialize_b2b_certificate_unregistered_error
 from ...b2b.counterparty.b2b_counterparty_brn_invalid_error import _deserialize_b2b_counterparty_brn_invalid_error
@@ -63,6 +64,38 @@ class CounterpartyClient:
         self._store_id = store_id
         self._async_client = AsyncClient(timeout=60.0)
         self._sync_client = SyncClient(timeout=60.0)
+
+    def close(self) -> None:
+        """Close the underlying synchronous HTTP client."""
+        self._sync_client.close()
+
+    async def aclose(self) -> None:
+        """Close the underlying synchronous and asynchronous HTTP clients."""
+        self._sync_client.close()
+        await self._async_client.aclose()
+
+    def __enter__(self) -> "CounterpartyClient":
+        return self
+
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_value: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> None:
+        self.close()
+
+    async def __aenter__(self) -> "CounterpartyClient":
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_value: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> None:
+        await self.aclose()
+
     def get_b2b_counterparty_certificate_registration_url(
         self,
         *,
@@ -757,7 +790,6 @@ class CounterpartyClient:
         query = []
         if test is not None:
             query.append(("test", test))
-        query.append(("requestBody", json.dumps(request_body)))
         response = self._sync_client.request(
             "DELETE",
             f"{self._base_url}/b2b/counterparties/{quote(counterparty_id, safe='')}",
@@ -846,7 +878,6 @@ class CounterpartyClient:
         query = []
         if test is not None:
             query.append(("test", test))
-        query.append(("requestBody", json.dumps(request_body)))
         response = await self._async_client.request(
             "DELETE",
             f"{self._base_url}/b2b/counterparties/{quote(counterparty_id, safe='')}",

--- a/python/src/portone_server_sdk/_generated/b2b/tax_invoice/client.py
+++ b/python/src/portone_server_sdk/_generated/b2b/tax_invoice/client.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 import httpx
 import json
+from types import TracebackType
 from httpx import AsyncClient, Client as SyncClient
 from ...._user_agent import USER_AGENT
-from typing import Optional
+from typing import Optional, Type
 from ...errors import B2BCannotChangeTaxTypeError, B2BTaxInvoiceStatusNotSendingCompletedError, B2bBulkTaxInvoiceNotFoundError, B2bCounterpartyNotFoundError, B2bCounterpartyNtsNotConnectedError, B2bDocumentKeyCannotBeChangedError, B2bExternalServiceError, B2bFileNotFoundError, B2bIdAlreadyExistsError, B2bIssuanceTypeMismatchError, B2bModificationNotProvidedError, B2bNotEnabledError, B2bOriginalTaxInvoiceNotFoundError, B2bRecipientNotFoundError, B2bSupplierNotFoundError, B2bTaxInvoiceAttachmentNotFoundError, B2bTaxInvoiceNoRecipientDocumentKeyError, B2bTaxInvoiceNoSupplierDocumentKeyError, B2bTaxInvoiceNonDeletableStatusError, B2bTaxInvoiceNotDraftedStatusError, B2bTaxInvoiceNotFoundError, B2bTaxInvoiceNotIssuedStatusError, B2bTaxInvoiceNotRequestedStatusError, B2bTaxInvoiceRecipientDocumentKeyAlreadyUsedError, B2bTaxInvoiceSupplierDocumentKeyAlreadyUsedError, ForbiddenError, InvalidRequestError, UnauthorizedError, UnknownError
 from ...b2b.tax_invoice.b2b_cannot_change_tax_type_error import _deserialize_b2b_cannot_change_tax_type_error
 from ...b2b.tax_invoice.b2b_tax_invoice_status_not_sending_completed_error import _deserialize_b2b_tax_invoice_status_not_sending_completed_error
@@ -80,6 +81,38 @@ class TaxInvoiceClient:
         self._store_id = store_id
         self._async_client = AsyncClient(timeout=60.0)
         self._sync_client = SyncClient(timeout=60.0)
+
+    def close(self) -> None:
+        """Close the underlying synchronous HTTP client."""
+        self._sync_client.close()
+
+    async def aclose(self) -> None:
+        """Close the underlying synchronous and asynchronous HTTP clients."""
+        self._sync_client.close()
+        await self._async_client.aclose()
+
+    def __enter__(self) -> "TaxInvoiceClient":
+        return self
+
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_value: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> None:
+        self.close()
+
+    async def __aenter__(self) -> "TaxInvoiceClient":
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_value: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> None:
+        await self.aclose()
+
     def get_b2b_bulk_tax_invoice(
         self,
         *,

--- a/python/src/portone_server_sdk/_generated/client.py
+++ b/python/src/portone_server_sdk/_generated/client.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
-from typing import Optional
+from types import TracebackType
+from typing import Optional, Type
 from .b2b.client import B2bClient
 from .platform.client import PlatformClient
 from .payment.client import PaymentClient
@@ -34,3 +35,45 @@ class PortOneClient:
         self.pg_specific = PgSpecificClient(secret=secret, base_url=base_url, store_id=store_id)
         self.auth = AuthClient(secret=secret, base_url=base_url, store_id=store_id)
         self.reconciliation = ReconciliationClient(secret=secret, base_url=base_url, store_id=store_id)
+
+    def close(self) -> None:
+        """Close the underlying synchronous HTTP client."""
+        self.b2b.close()
+        self.platform.close()
+        self.payment.close()
+        self.identity_verification.close()
+        self.pg_specific.close()
+        self.auth.close()
+        self.reconciliation.close()
+
+    async def aclose(self) -> None:
+        """Close the underlying synchronous and asynchronous HTTP clients."""
+        await self.b2b.aclose()
+        await self.platform.aclose()
+        await self.payment.aclose()
+        await self.identity_verification.aclose()
+        await self.pg_specific.aclose()
+        await self.auth.aclose()
+        await self.reconciliation.aclose()
+
+    def __enter__(self) -> "PortOneClient":
+        return self
+
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_value: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> None:
+        self.close()
+
+    async def __aenter__(self) -> "PortOneClient":
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_value: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> None:
+        await self.aclose()

--- a/python/src/portone_server_sdk/_generated/identity_verification/client.py
+++ b/python/src/portone_server_sdk/_generated/identity_verification/client.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 import httpx
 import json
+from types import TracebackType
 from httpx import AsyncClient, Client as SyncClient
 from ..._user_agent import USER_AGENT
-from typing import Optional
+from typing import Optional, Type
 from ..errors import ChannelNotFoundError, ForbiddenError, IdentityVerificationAlreadySentError, IdentityVerificationAlreadyVerifiedError, IdentityVerificationNotFoundError, IdentityVerificationNotSentError, InvalidRequestError, MaxTransactionCountReachedError, PgProviderError, UnauthorizedError, UnknownError
 from ..common.channel_not_found_error import _deserialize_channel_not_found_error
 from ..common.forbidden_error import _deserialize_forbidden_error
@@ -48,6 +49,38 @@ class IdentityVerificationClient:
         self._store_id = store_id
         self._async_client = AsyncClient(timeout=60.0)
         self._sync_client = SyncClient(timeout=60.0)
+
+    def close(self) -> None:
+        """Close the underlying synchronous HTTP client."""
+        self._sync_client.close()
+
+    async def aclose(self) -> None:
+        """Close the underlying synchronous and asynchronous HTTP clients."""
+        self._sync_client.close()
+        await self._async_client.aclose()
+
+    def __enter__(self) -> "IdentityVerificationClient":
+        return self
+
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_value: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> None:
+        self.close()
+
+    async def __aenter__(self) -> "IdentityVerificationClient":
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_value: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> None:
+        await self.aclose()
+
     def confirm_identity_verification(
         self,
         *,

--- a/python/src/portone_server_sdk/_generated/payment/additional_feature/client.py
+++ b/python/src/portone_server_sdk/_generated/payment/additional_feature/client.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 import httpx
 import json
+from types import TracebackType
 from httpx import AsyncClient, Client as SyncClient
 from ...._user_agent import USER_AGENT
-from typing import Optional
+from typing import Optional, Type
 from ...errors import ChannelNotFoundError, InvalidRequestError, PgProviderError, UnauthorizedError, UnknownError
 from ...common.channel_not_found_error import _deserialize_channel_not_found_error
 from ...common.invalid_request_error import _deserialize_invalid_request_error
@@ -33,6 +34,38 @@ class AdditionalFeatureClient:
         self._store_id = store_id
         self._async_client = AsyncClient(timeout=60.0)
         self._sync_client = SyncClient(timeout=60.0)
+
+    def close(self) -> None:
+        """Close the underlying synchronous HTTP client."""
+        self._sync_client.close()
+
+    async def aclose(self) -> None:
+        """Close the underlying synchronous and asynchronous HTTP clients."""
+        self._sync_client.close()
+        await self._async_client.aclose()
+
+    def __enter__(self) -> "AdditionalFeatureClient":
+        return self
+
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_value: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> None:
+        self.close()
+
+    async def __aenter__(self) -> "AdditionalFeatureClient":
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_value: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> None:
+        await self.aclose()
+
     def get_pg_card_promotions(
         self,
         *,

--- a/python/src/portone_server_sdk/_generated/payment/billing_key/client.py
+++ b/python/src/portone_server_sdk/_generated/payment/billing_key/client.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 import httpx
 import json
+from types import TracebackType
 from httpx import AsyncClient, Client as SyncClient
 from ...._user_agent import USER_AGENT
-from typing import Optional
+from typing import Optional, Type
 from ...errors import BillingKeyAlreadyDeletedError, BillingKeyAlreadyIssuedError, BillingKeyNotFoundError, BillingKeyNotIssuedError, ChannelNotFoundError, ChannelSpecificError, ForbiddenError, InformationMismatchError, InvalidRequestError, PaymentScheduleAlreadyExistsError, PgProviderError, UnauthorizedError, UnknownError
 from ...common.billing_key_already_deleted_error import _deserialize_billing_key_already_deleted_error
 from ...payment.billing_key.billing_key_already_issued_error import _deserialize_billing_key_already_issued_error
@@ -52,6 +53,38 @@ class BillingKeyClient:
         self._store_id = store_id
         self._async_client = AsyncClient(timeout=60.0)
         self._sync_client = SyncClient(timeout=60.0)
+
+    def close(self) -> None:
+        """Close the underlying synchronous HTTP client."""
+        self._sync_client.close()
+
+    async def aclose(self) -> None:
+        """Close the underlying synchronous and asynchronous HTTP clients."""
+        self._sync_client.close()
+        await self._async_client.aclose()
+
+    def __enter__(self) -> "BillingKeyClient":
+        return self
+
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_value: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> None:
+        self.close()
+
+    async def __aenter__(self) -> "BillingKeyClient":
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_value: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> None:
+        await self.aclose()
+
     def get_billing_key_infos(
         self,
         *,

--- a/python/src/portone_server_sdk/_generated/payment/cash_receipt/client.py
+++ b/python/src/portone_server_sdk/_generated/payment/cash_receipt/client.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 import httpx
 import json
+from types import TracebackType
 from httpx import AsyncClient, Client as SyncClient
 from ...._user_agent import USER_AGENT
-from typing import Optional
+from typing import Optional, Type
 from ...errors import CashReceiptAlreadyIssuedError, CashReceiptNotFoundError, CashReceiptNotIssuedError, ChannelNotFoundError, ForbiddenError, InvalidRequestError, PgProviderError, UnauthorizedError, UnknownError
 from ...payment.cash_receipt.cash_receipt_already_issued_error import _deserialize_cash_receipt_already_issued_error
 from ...payment.cash_receipt.cash_receipt_not_found_error import _deserialize_cash_receipt_not_found_error
@@ -48,6 +49,38 @@ class CashReceiptClient:
         self._store_id = store_id
         self._async_client = AsyncClient(timeout=60.0)
         self._sync_client = SyncClient(timeout=60.0)
+
+    def close(self) -> None:
+        """Close the underlying synchronous HTTP client."""
+        self._sync_client.close()
+
+    async def aclose(self) -> None:
+        """Close the underlying synchronous and asynchronous HTTP clients."""
+        self._sync_client.close()
+        await self._async_client.aclose()
+
+    def __enter__(self) -> "CashReceiptClient":
+        return self
+
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_value: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> None:
+        self.close()
+
+    async def __aenter__(self) -> "CashReceiptClient":
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_value: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> None:
+        await self.aclose()
+
     def get_cash_receipts(
         self,
         *,

--- a/python/src/portone_server_sdk/_generated/payment/client.py
+++ b/python/src/portone_server_sdk/_generated/payment/client.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 import httpx
 import json
+from types import TracebackType
 from httpx import AsyncClient, Client as SyncClient
 from ..._user_agent import USER_AGENT
-from typing import Optional
+from typing import Optional, Type
 from ..errors import AlreadyPaidError, BillingKeyAlreadyDeletedError, BillingKeyNotFoundError, CancelAmountExceedsCancellableAmountError, CancelTaxAmountExceedsCancellableTaxAmountError, CancelTaxFreeAmountExceedsCancellableTaxFreeAmountError, CancellableAmountConsistencyBrokenError, ChannelNotFoundError, DiscountAmountExceedsTotalAmountError, ForbiddenError, InformationMismatchError, InvalidPaymentTokenError, InvalidRequestError, MaxTransactionCountReachedError, MaxWebhookRetryCountReachedError, NegativePromotionAdjustedCancelAmountError, PaymentAlreadyCancelledError, PaymentCancellationNotFoundError, PaymentCancellationNotPendingError, PaymentNotFoundError, PaymentNotPaidError, PaymentNotWaitingForDepositError, PaymentScheduleAlreadyExistsError, PgProviderError, PromotionDiscountRetainOptionShouldNotBeChangedError, PromotionPayMethodDoesNotMatchError, SumOfPartsExceedsCancelAmountError, SumOfPartsExceedsTotalAmountError, UnauthorizedError, UnknownError, WebhookNotFoundError
 from ..payment.already_paid_error import _deserialize_already_paid_error
 from ..common.billing_key_already_deleted_error import _deserialize_billing_key_already_deleted_error
@@ -109,6 +110,48 @@ class PaymentClient:
         self.additional_feature = AdditionalFeatureClient(secret=secret, base_url=base_url, store_id=store_id)
         self.payment_schedule = PaymentScheduleClient(secret=secret, base_url=base_url, store_id=store_id)
         self.promotion = PromotionClient(secret=secret, base_url=base_url, store_id=store_id)
+
+    def close(self) -> None:
+        """Close the underlying synchronous HTTP client."""
+        self._sync_client.close()
+        self.billing_key.close()
+        self.cash_receipt.close()
+        self.additional_feature.close()
+        self.payment_schedule.close()
+        self.promotion.close()
+
+    async def aclose(self) -> None:
+        """Close the underlying synchronous and asynchronous HTTP clients."""
+        self._sync_client.close()
+        await self._async_client.aclose()
+        await self.billing_key.aclose()
+        await self.cash_receipt.aclose()
+        await self.additional_feature.aclose()
+        await self.payment_schedule.aclose()
+        await self.promotion.aclose()
+
+    def __enter__(self) -> "PaymentClient":
+        return self
+
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_value: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> None:
+        self.close()
+
+    async def __aenter__(self) -> "PaymentClient":
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_value: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> None:
+        await self.aclose()
+
     def get_all_payment_events_by_cursor(
         self,
         *,

--- a/python/src/portone_server_sdk/_generated/payment/payment_schedule/client.py
+++ b/python/src/portone_server_sdk/_generated/payment/payment_schedule/client.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 import httpx
 import json
+from types import TracebackType
 from httpx import AsyncClient, Client as SyncClient
 from ...._user_agent import USER_AGENT
-from typing import Optional
+from typing import Optional, Type
 from ...errors import AlreadyPaidOrWaitingError, BillingKeyAlreadyDeletedError, BillingKeyNotFoundError, ForbiddenError, InvalidRequestError, PaymentScheduleAlreadyExistsError, PaymentScheduleAlreadyProcessedError, PaymentScheduleAlreadyRevokedError, PaymentScheduleNotFoundError, SumOfPartsExceedsTotalAmountError, UnauthorizedError, UnknownError
 from ...payment.payment_schedule.already_paid_or_waiting_error import _deserialize_already_paid_or_waiting_error
 from ...common.billing_key_already_deleted_error import _deserialize_billing_key_already_deleted_error
@@ -46,6 +47,38 @@ class PaymentScheduleClient:
         self._store_id = store_id
         self._async_client = AsyncClient(timeout=60.0)
         self._sync_client = SyncClient(timeout=60.0)
+
+    def close(self) -> None:
+        """Close the underlying synchronous HTTP client."""
+        self._sync_client.close()
+
+    async def aclose(self) -> None:
+        """Close the underlying synchronous and asynchronous HTTP clients."""
+        self._sync_client.close()
+        await self._async_client.aclose()
+
+    def __enter__(self) -> "PaymentScheduleClient":
+        return self
+
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_value: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> None:
+        self.close()
+
+    async def __aenter__(self) -> "PaymentScheduleClient":
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_value: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> None:
+        await self.aclose()
+
     def get_payment_schedule(
         self,
         *,

--- a/python/src/portone_server_sdk/_generated/payment/promotion/client.py
+++ b/python/src/portone_server_sdk/_generated/payment/promotion/client.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 import httpx
 import json
+from types import TracebackType
 from httpx import AsyncClient, Client as SyncClient
 from ...._user_agent import USER_AGENT
-from typing import Optional
+from typing import Optional, Type
 from ...errors import ForbiddenError, InvalidRequestError, PromotionNotFoundError, UnauthorizedError, UnknownError
 from ...common.forbidden_error import _deserialize_forbidden_error
 from ...common.invalid_request_error import _deserialize_invalid_request_error
@@ -32,6 +33,38 @@ class PromotionClient:
         self._store_id = store_id
         self._async_client = AsyncClient(timeout=60.0)
         self._sync_client = SyncClient(timeout=60.0)
+
+    def close(self) -> None:
+        """Close the underlying synchronous HTTP client."""
+        self._sync_client.close()
+
+    async def aclose(self) -> None:
+        """Close the underlying synchronous and asynchronous HTTP clients."""
+        self._sync_client.close()
+        await self._async_client.aclose()
+
+    def __enter__(self) -> "PromotionClient":
+        return self
+
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_value: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> None:
+        self.close()
+
+    async def __aenter__(self) -> "PromotionClient":
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_value: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> None:
+        await self.aclose()
+
     def get_promotion(
         self,
         *,

--- a/python/src/portone_server_sdk/_generated/pg_specific/client.py
+++ b/python/src/portone_server_sdk/_generated/pg_specific/client.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 import httpx
 import json
+from types import TracebackType
 from httpx import AsyncClient, Client as SyncClient
 from ..._user_agent import USER_AGENT
-from typing import Optional
+from typing import Optional, Type
 from ..errors import InvalidRequestError, PaymentNotFoundError, UnauthorizedError, UnknownError
 from ..common.invalid_request_error import _deserialize_invalid_request_error
 from ..common.payment_not_found_error import _deserialize_payment_not_found_error
@@ -35,6 +36,38 @@ class PgSpecificClient:
         self._store_id = store_id
         self._async_client = AsyncClient(timeout=60.0)
         self._sync_client = SyncClient(timeout=60.0)
+
+    def close(self) -> None:
+        """Close the underlying synchronous HTTP client."""
+        self._sync_client.close()
+
+    async def aclose(self) -> None:
+        """Close the underlying synchronous and asynchronous HTTP clients."""
+        self._sync_client.close()
+        await self._async_client.aclose()
+
+    def __enter__(self) -> "PgSpecificClient":
+        return self
+
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_value: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> None:
+        self.close()
+
+    async def __aenter__(self) -> "PgSpecificClient":
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_value: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> None:
+        await self.aclose()
+
     def get_kakaopay_payment_order(
         self,
         *,

--- a/python/src/portone_server_sdk/_generated/platform/account/client.py
+++ b/python/src/portone_server_sdk/_generated/platform/account/client.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 import httpx
 import json
+from types import TracebackType
 from httpx import AsyncClient, Client as SyncClient
 from ...._user_agent import USER_AGENT
-from typing import Optional
+from typing import Optional, Type
 from ...errors import ForbiddenError, InvalidRequestError, PlatformExternalApiFailedError, PlatformExternalApiTemporarilyFailedError, PlatformNotEnabledError, PlatformNotSupportedBankError, UnauthorizedError, UnknownError
 from ...common.forbidden_error import _deserialize_forbidden_error
 from ...common.invalid_request_error import _deserialize_invalid_request_error
@@ -36,6 +37,38 @@ class AccountClient:
         self._store_id = store_id
         self._async_client = AsyncClient(timeout=60.0)
         self._sync_client = SyncClient(timeout=60.0)
+
+    def close(self) -> None:
+        """Close the underlying synchronous HTTP client."""
+        self._sync_client.close()
+
+    async def aclose(self) -> None:
+        """Close the underlying synchronous and asynchronous HTTP clients."""
+        self._sync_client.close()
+        await self._async_client.aclose()
+
+    def __enter__(self) -> "AccountClient":
+        return self
+
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_value: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> None:
+        self.close()
+
+    async def __aenter__(self) -> "AccountClient":
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_value: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> None:
+        await self.aclose()
+
     def get_platform_account_holder(
         self,
         *,

--- a/python/src/portone_server_sdk/_generated/platform/account_transfer/client.py
+++ b/python/src/portone_server_sdk/_generated/platform/account_transfer/client.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 import httpx
 import json
+from types import TracebackType
 from httpx import AsyncClient, Client as SyncClient
 from ...._user_agent import USER_AGENT
-from typing import Optional
+from typing import Optional, Type
 from ...errors import ForbiddenError, InvalidRequestError, PlatformNotEnabledError, UnauthorizedError, UnknownError
 from ...common.forbidden_error import _deserialize_forbidden_error
 from ...common.invalid_request_error import _deserialize_invalid_request_error
@@ -34,6 +35,38 @@ class AccountTransferClient:
         self._store_id = store_id
         self._async_client = AsyncClient(timeout=60.0)
         self._sync_client = SyncClient(timeout=60.0)
+
+    def close(self) -> None:
+        """Close the underlying synchronous HTTP client."""
+        self._sync_client.close()
+
+    async def aclose(self) -> None:
+        """Close the underlying synchronous and asynchronous HTTP clients."""
+        self._sync_client.close()
+        await self._async_client.aclose()
+
+    def __enter__(self) -> "AccountTransferClient":
+        return self
+
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_value: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> None:
+        self.close()
+
+    async def __aenter__(self) -> "AccountTransferClient":
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_value: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> None:
+        await self.aclose()
+
     def get_platform_account_transfers(
         self,
         *,

--- a/python/src/portone_server_sdk/_generated/platform/bulk_account_transfer/client.py
+++ b/python/src/portone_server_sdk/_generated/platform/bulk_account_transfer/client.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 import httpx
 import json
+from types import TracebackType
 from httpx import AsyncClient, Client as SyncClient
 from ...._user_agent import USER_AGENT
-from typing import Optional
+from typing import Optional, Type
 from ...errors import ForbiddenError, InvalidRequestError, PlatformNotEnabledError, UnauthorizedError, UnknownError
 from ...common.forbidden_error import _deserialize_forbidden_error
 from ...common.invalid_request_error import _deserialize_invalid_request_error
@@ -34,6 +35,38 @@ class BulkAccountTransferClient:
         self._store_id = store_id
         self._async_client = AsyncClient(timeout=60.0)
         self._sync_client = SyncClient(timeout=60.0)
+
+    def close(self) -> None:
+        """Close the underlying synchronous HTTP client."""
+        self._sync_client.close()
+
+    async def aclose(self) -> None:
+        """Close the underlying synchronous and asynchronous HTTP clients."""
+        self._sync_client.close()
+        await self._async_client.aclose()
+
+    def __enter__(self) -> "BulkAccountTransferClient":
+        return self
+
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_value: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> None:
+        self.close()
+
+    async def __aenter__(self) -> "BulkAccountTransferClient":
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_value: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> None:
+        await self.aclose()
+
     def get_platform_bulk_account_transfers(
         self,
         *,

--- a/python/src/portone_server_sdk/_generated/platform/bulk_payout/client.py
+++ b/python/src/portone_server_sdk/_generated/platform/bulk_payout/client.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 import httpx
 import json
+from types import TracebackType
 from httpx import AsyncClient, Client as SyncClient
 from ...._user_agent import USER_AGENT
-from typing import Optional
+from typing import Optional, Type
 from ...errors import ForbiddenError, InvalidRequestError, PlatformNotEnabledError, UnauthorizedError, UnknownError
 from ...common.forbidden_error import _deserialize_forbidden_error
 from ...common.invalid_request_error import _deserialize_invalid_request_error
@@ -34,6 +35,38 @@ class BulkPayoutClient:
         self._store_id = store_id
         self._async_client = AsyncClient(timeout=60.0)
         self._sync_client = SyncClient(timeout=60.0)
+
+    def close(self) -> None:
+        """Close the underlying synchronous HTTP client."""
+        self._sync_client.close()
+
+    async def aclose(self) -> None:
+        """Close the underlying synchronous and asynchronous HTTP clients."""
+        self._sync_client.close()
+        await self._async_client.aclose()
+
+    def __enter__(self) -> "BulkPayoutClient":
+        return self
+
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_value: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> None:
+        self.close()
+
+    async def __aenter__(self) -> "BulkPayoutClient":
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_value: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> None:
+        await self.aclose()
+
     def get_platform_bulk_payouts(
         self,
         *,

--- a/python/src/portone_server_sdk/_generated/platform/client.py
+++ b/python/src/portone_server_sdk/_generated/platform/client.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 import httpx
 import json
+from types import TracebackType
 from httpx import AsyncClient, Client as SyncClient
 from ..._user_agent import USER_AGENT
-from typing import Optional
+from typing import Optional, Type
 from ..errors import ForbiddenError, InvalidRequestError, PlatformAccountVerificationAlreadyUsedError, PlatformAccountVerificationFailedError, PlatformAccountVerificationNotFoundError, PlatformAdditionalFeePolicyNotFoundError, PlatformAdditionalFeePolicyScheduleAlreadyExistsError, PlatformArchivedAdditionalFeePolicyError, PlatformArchivedContractError, PlatformArchivedDiscountSharePolicyError, PlatformArchivedPartnerError, PlatformArchivedPartnersCannotBeScheduledError, PlatformCompanyVerificationAlreadyUsedError, PlatformContractNotFoundError, PlatformContractScheduleAlreadyExistsError, PlatformDiscountSharePolicyNotFoundError, PlatformDiscountSharePolicyScheduleAlreadyExistsError, PlatformInsufficientDataToChangePartnerTypeError, PlatformMemberCompanyConnectedPartnerBrnUnchangeableError, PlatformMemberCompanyConnectedPartnerCannotBeScheduledError, PlatformMemberCompanyConnectedPartnerTypeUnchangeableError, PlatformMemberCompanyConnectedPartnersCannotBeScheduledError, PlatformNotEnabledError, PlatformPartnerNotFoundError, PlatformPartnerScheduleAlreadyExistsError, PlatformPartnerSchedulesAlreadyExistError, PlatformUserDefinedPropertyNotFoundError, UnauthorizedError, UnknownError
 from ..common.forbidden_error import _deserialize_forbidden_error
 from ..common.invalid_request_error import _deserialize_invalid_request_error
@@ -113,6 +114,58 @@ class PlatformClient:
         self.partner_settlement = PartnerSettlementClient(secret=secret, base_url=base_url, store_id=store_id)
         self.partner = PartnerClient(secret=secret, base_url=base_url, store_id=store_id)
         self.transfer = TransferClient(secret=secret, base_url=base_url, store_id=store_id)
+
+    def close(self) -> None:
+        """Close the underlying synchronous HTTP client."""
+        self._sync_client.close()
+        self.company.close()
+        self.account_transfer.close()
+        self.policy.close()
+        self.account.close()
+        self.bulk_account_transfer.close()
+        self.bulk_payout.close()
+        self.payout.close()
+        self.partner_settlement.close()
+        self.partner.close()
+        self.transfer.close()
+
+    async def aclose(self) -> None:
+        """Close the underlying synchronous and asynchronous HTTP clients."""
+        self._sync_client.close()
+        await self._async_client.aclose()
+        await self.company.aclose()
+        await self.account_transfer.aclose()
+        await self.policy.aclose()
+        await self.account.aclose()
+        await self.bulk_account_transfer.aclose()
+        await self.bulk_payout.aclose()
+        await self.payout.aclose()
+        await self.partner_settlement.aclose()
+        await self.partner.aclose()
+        await self.transfer.aclose()
+
+    def __enter__(self) -> "PlatformClient":
+        return self
+
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_value: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> None:
+        self.close()
+
+    async def __aenter__(self) -> "PlatformClient":
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_value: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> None:
+        await self.aclose()
+
     def get_platform_additional_fee_policy_schedule(
         self,
         *,

--- a/python/src/portone_server_sdk/_generated/platform/company/client.py
+++ b/python/src/portone_server_sdk/_generated/platform/company/client.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 import httpx
 import json
+from types import TracebackType
 from httpx import AsyncClient, Client as SyncClient
 from ...._user_agent import USER_AGENT
-from typing import Optional
+from typing import Optional, Type
 from ...errors import B2bExternalServiceError, B2bNotEnabledError, ForbiddenError, InvalidRequestError, PlatformCompanyNotFoundError, PlatformExternalApiFailedError, PlatformNotEnabledError, UnauthorizedError, UnknownError
 from ...common.b2b_external_service_error import _deserialize_b2b_external_service_error
 from ...common.b2b_not_enabled_error import _deserialize_b2b_not_enabled_error
@@ -37,6 +38,38 @@ class CompanyClient:
         self._store_id = store_id
         self._async_client = AsyncClient(timeout=60.0)
         self._sync_client = SyncClient(timeout=60.0)
+
+    def close(self) -> None:
+        """Close the underlying synchronous HTTP client."""
+        self._sync_client.close()
+
+    async def aclose(self) -> None:
+        """Close the underlying synchronous and asynchronous HTTP clients."""
+        self._sync_client.close()
+        await self._async_client.aclose()
+
+    def __enter__(self) -> "CompanyClient":
+        return self
+
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_value: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> None:
+        self.close()
+
+    async def __aenter__(self) -> "CompanyClient":
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_value: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> None:
+        await self.aclose()
+
     def get_b2b_business_infos(
         self,
         *,

--- a/python/src/portone_server_sdk/_generated/platform/partner/client.py
+++ b/python/src/portone_server_sdk/_generated/platform/partner/client.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 import httpx
 import json
+from types import TracebackType
 from httpx import AsyncClient, Client as SyncClient
 from ...._user_agent import USER_AGENT
-from typing import Optional
+from typing import Optional, Type
 from ...errors import ForbiddenError, InvalidRequestError, PlatformAccountVerificationAlreadyUsedError, PlatformAccountVerificationFailedError, PlatformAccountVerificationNotFoundError, PlatformArchivedPartnerError, PlatformArchivedPartnerNtsNotAllowedError, PlatformBtxNotEnabledError, PlatformCannotArchiveScheduledPartnerError, PlatformCompanyVerificationAlreadyUsedError, PlatformContractNotFoundError, PlatformContractsNotFoundError, PlatformCounterpartyNotConnectableStatusError, PlatformCounterpartyNotConnectedError, PlatformCounterpartyOngoingTaxInvoiceExistsError, PlatformCurrencyNotSupportedError, PlatformExternalApiFailedError, PlatformInsufficientDataToChangePartnerTypeError, PlatformMemberCompanyConnectedPartnerBrnUnchangeableError, PlatformMemberCompanyConnectedPartnerTypeUnchangeableError, PlatformNotEnabledError, PlatformOngoingTaxInvoiceExistsError, PlatformPartnerIdAlreadyExistsError, PlatformPartnerIdsAlreadyExistError, PlatformPartnerIdsDuplicatedError, PlatformPartnerNotFoundError, PlatformPartnerPendingNtsOperationError, PlatformPartnerScheduleExistsError, PlatformPartnerTaxationTypeIsSimpleError, PlatformPartnerTypeIsNotBusinessError, PlatformTargetPartnerNotFoundError, PlatformUserDefinedPropertyNotFoundError, UnauthorizedError, UnknownError
 from ...common.forbidden_error import _deserialize_forbidden_error
 from ...common.invalid_request_error import _deserialize_invalid_request_error
@@ -81,6 +82,38 @@ class PartnerClient:
         self._store_id = store_id
         self._async_client = AsyncClient(timeout=60.0)
         self._sync_client = SyncClient(timeout=60.0)
+
+    def close(self) -> None:
+        """Close the underlying synchronous HTTP client."""
+        self._sync_client.close()
+
+    async def aclose(self) -> None:
+        """Close the underlying synchronous and asynchronous HTTP clients."""
+        self._sync_client.close()
+        await self._async_client.aclose()
+
+    def __enter__(self) -> "PartnerClient":
+        return self
+
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_value: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> None:
+        self.close()
+
+    async def __aenter__(self) -> "PartnerClient":
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_value: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> None:
+        await self.aclose()
+
     def create_platform_partners(
         self,
         *,

--- a/python/src/portone_server_sdk/_generated/platform/partner_settlement/client.py
+++ b/python/src/portone_server_sdk/_generated/platform/partner_settlement/client.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 import httpx
 import json
+from types import TracebackType
 from httpx import AsyncClient, Client as SyncClient
 from ...._user_agent import USER_AGENT
-from typing import Optional
+from typing import Optional, Type
 from ...errors import ForbiddenError, InvalidRequestError, PlatformNonDeletablePartnerSettlementsError, PlatformNotEnabledError, PlatformPartnerSettlementsNotFoundError, PlatformReferencedCancelOrderTransfersExistError, UnauthorizedError, UnknownError
 from ...common.forbidden_error import _deserialize_forbidden_error
 from ...common.invalid_request_error import _deserialize_invalid_request_error
@@ -38,6 +39,38 @@ class PartnerSettlementClient:
         self._store_id = store_id
         self._async_client = AsyncClient(timeout=60.0)
         self._sync_client = SyncClient(timeout=60.0)
+
+    def close(self) -> None:
+        """Close the underlying synchronous HTTP client."""
+        self._sync_client.close()
+
+    async def aclose(self) -> None:
+        """Close the underlying synchronous and asynchronous HTTP clients."""
+        self._sync_client.close()
+        await self._async_client.aclose()
+
+    def __enter__(self) -> "PartnerSettlementClient":
+        return self
+
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_value: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> None:
+        self.close()
+
+    async def __aenter__(self) -> "PartnerSettlementClient":
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_value: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> None:
+        await self.aclose()
+
     def delete_platform_partner_settlements(
         self,
         *,

--- a/python/src/portone_server_sdk/_generated/platform/payout/client.py
+++ b/python/src/portone_server_sdk/_generated/platform/payout/client.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 import httpx
 import json
+from types import TracebackType
 from httpx import AsyncClient, Client as SyncClient
 from ...._user_agent import USER_AGENT
-from typing import Optional
+from typing import Optional, Type
 from ...errors import ForbiddenError, InvalidRequestError, PlatformBulkPayoutIdAlreadyExistsError, PlatformDuplicatedPartnerSettlementIdsError, PlatformNegativePayoutAmountPartnersError, PlatformNoSelectedPartnerSettlementsError, PlatformNonPayablePartnerSettlementsError, PlatformNotEnabledError, PlatformPartnerSettlementsNotFoundError, UnauthorizedError, UnknownError
 from ...common.forbidden_error import _deserialize_forbidden_error
 from ...common.invalid_request_error import _deserialize_invalid_request_error
@@ -41,6 +42,38 @@ class PayoutClient:
         self._store_id = store_id
         self._async_client = AsyncClient(timeout=60.0)
         self._sync_client = SyncClient(timeout=60.0)
+
+    def close(self) -> None:
+        """Close the underlying synchronous HTTP client."""
+        self._sync_client.close()
+
+    async def aclose(self) -> None:
+        """Close the underlying synchronous and asynchronous HTTP clients."""
+        self._sync_client.close()
+        await self._async_client.aclose()
+
+    def __enter__(self) -> "PayoutClient":
+        return self
+
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_value: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> None:
+        self.close()
+
+    async def __aenter__(self) -> "PayoutClient":
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_value: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> None:
+        await self.aclose()
+
     def complete_platform_payout_by_partner_settlement_ids(
         self,
         *,

--- a/python/src/portone_server_sdk/_generated/platform/policy/client.py
+++ b/python/src/portone_server_sdk/_generated/platform/policy/client.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 import httpx
 import json
+from types import TracebackType
 from httpx import AsyncClient, Client as SyncClient
 from ...._user_agent import USER_AGENT
-from typing import Optional
+from typing import Optional, Type
 from ...errors import ForbiddenError, InvalidRequestError, PlatformAdditionalFeePolicyAlreadyExistsError, PlatformAdditionalFeePolicyNotFoundError, PlatformArchivedAdditionalFeePolicyError, PlatformArchivedContractError, PlatformArchivedDiscountSharePolicyError, PlatformCannotArchiveScheduledAdditionalFeePolicyError, PlatformCannotArchiveScheduledContractError, PlatformCannotArchiveScheduledDiscountSharePolicyError, PlatformContractAlreadyExistsError, PlatformContractNotFoundError, PlatformDiscountSharePolicyAlreadyExistsError, PlatformDiscountSharePolicyNotFoundError, PlatformNotEnabledError, UnauthorizedError, UnknownError
 from ...common.forbidden_error import _deserialize_forbidden_error
 from ...common.invalid_request_error import _deserialize_invalid_request_error
@@ -68,6 +69,38 @@ class PolicyClient:
         self._store_id = store_id
         self._async_client = AsyncClient(timeout=60.0)
         self._sync_client = SyncClient(timeout=60.0)
+
+    def close(self) -> None:
+        """Close the underlying synchronous HTTP client."""
+        self._sync_client.close()
+
+    async def aclose(self) -> None:
+        """Close the underlying synchronous and asynchronous HTTP clients."""
+        self._sync_client.close()
+        await self._async_client.aclose()
+
+    def __enter__(self) -> "PolicyClient":
+        return self
+
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_value: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> None:
+        self.close()
+
+    async def __aenter__(self) -> "PolicyClient":
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_value: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> None:
+        await self.aclose()
+
     def archive_platform_additional_fee_policy(
         self,
         *,

--- a/python/src/portone_server_sdk/_generated/platform/transfer/client.py
+++ b/python/src/portone_server_sdk/_generated/platform/transfer/client.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 import httpx
 import json
+from types import TracebackType
 from httpx import AsyncClient, Client as SyncClient
 from ...._user_agent import USER_AGENT
-from typing import Optional
+from typing import Optional, Type
 from ...errors import ForbiddenError, InvalidRequestError, PlatformAdditionalFeePoliciesNotFoundError, PlatformAdditionalFixedAmountFeeCurrencyAndSettlementCurrencyMismatchedError, PlatformCancelOrderTransfersExistsError, PlatformCancellableAmountExceededError, PlatformCancellableDiscountAmountExceededError, PlatformCancellableDiscountTaxFreeAmountExceededError, PlatformCancellableProductQuantityExceededError, PlatformCancellationAndPaymentTypeMismatchedError, PlatformCancellationNotFoundError, PlatformCannotSpecifyTransferError, PlatformContractNotFoundError, PlatformContractPlatformFixedAmountFeeCurrencyAndSettlementCurrencyMismatchedError, PlatformCurrencyNotSupportedError, PlatformDiscountSharePoliciesNotFoundError, PlatformDiscountSharePolicyIdDuplicatedError, PlatformNotEnabledError, PlatformOrderDetailMismatchedError, PlatformOrderTransferAlreadyCancelledError, PlatformPartnerNotFoundError, PlatformPaymentNotFoundError, PlatformProductIdDuplicatedError, PlatformProductIdNotFoundError, PlatformSettlementAmountExceededError, PlatformSettlementCancelAmountExceededPortOneCancelError, PlatformSettlementDateEarlierThanSettlementStartDateError, PlatformSettlementParameterNotFoundError, PlatformSettlementPaymentAmountExceededPortOnePaymentError, PlatformSettlementSupplyWithVatAmountExceededPortOnePaymentError, PlatformSettlementTaxFreeAmountExceededPortOnePaymentError, PlatformTransferAlreadyExistsError, PlatformTransferDiscountSharePolicyNotFoundError, PlatformTransferIdAlreadyUsedError, PlatformTransferNonDeletableStatusError, PlatformTransferNotFoundError, PlatformUserDefinedPropertyNotFoundError, UnauthorizedError, UnknownError
 from ...common.forbidden_error import _deserialize_forbidden_error
 from ...common.invalid_request_error import _deserialize_invalid_request_error
@@ -83,6 +84,38 @@ class TransferClient:
         self._store_id = store_id
         self._async_client = AsyncClient(timeout=60.0)
         self._sync_client = SyncClient(timeout=60.0)
+
+    def close(self) -> None:
+        """Close the underlying synchronous HTTP client."""
+        self._sync_client.close()
+
+    async def aclose(self) -> None:
+        """Close the underlying synchronous and asynchronous HTTP clients."""
+        self._sync_client.close()
+        await self._async_client.aclose()
+
+    def __enter__(self) -> "TransferClient":
+        return self
+
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_value: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> None:
+        self.close()
+
+    async def __aenter__(self) -> "TransferClient":
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_value: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> None:
+        await self.aclose()
+
     def download_platform_transfer_sheet(
         self,
         *,

--- a/python/src/portone_server_sdk/_generated/reconciliation/client.py
+++ b/python/src/portone_server_sdk/_generated/reconciliation/client.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 import httpx
 import json
+from types import TracebackType
 from httpx import AsyncClient, Client as SyncClient
 from ..._user_agent import USER_AGENT
-from typing import Optional
+from typing import Optional, Type
 from ..errors import ForbiddenError, InvalidRequestError, UnauthorizedError, UnknownError
 from ..common.forbidden_error import _deserialize_forbidden_error
 from ..common.invalid_request_error import _deserialize_invalid_request_error
@@ -35,6 +36,38 @@ class ReconciliationClient:
         self._store_id = store_id
         self._async_client = AsyncClient(timeout=60.0)
         self._sync_client = SyncClient(timeout=60.0)
+
+    def close(self) -> None:
+        """Close the underlying synchronous HTTP client."""
+        self._sync_client.close()
+
+    async def aclose(self) -> None:
+        """Close the underlying synchronous and asynchronous HTTP clients."""
+        self._sync_client.close()
+        await self._async_client.aclose()
+
+    def __enter__(self) -> "ReconciliationClient":
+        return self
+
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_value: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> None:
+        self.close()
+
+    async def __aenter__(self) -> "ReconciliationClient":
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_value: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> None:
+        await self.aclose()
+
     def get_payment_reconciliation_settlement_vat_report(
         self,
         *,

--- a/python/tests/test_client_lifecycle.py
+++ b/python/tests/test_client_lifecycle.py
@@ -1,0 +1,65 @@
+import asyncio
+
+from portone_server_sdk import PaymentClient, PortOneClient
+
+
+def test_payment_client_close_closes_sync_client_tree():
+    client = PaymentClient(secret="test")
+
+    try:
+        assert not client._sync_client.is_closed
+        assert not client.billing_key._sync_client.is_closed
+
+        client.close()
+
+        assert client._sync_client.is_closed
+        assert client.billing_key._sync_client.is_closed
+    finally:
+        asyncio.run(client.aclose())
+
+
+def test_payment_client_aclose_closes_sync_and_async_client_tree():
+    client = PaymentClient(secret="test")
+
+    async def close_client():
+        await client.aclose()
+
+    asyncio.run(close_client())
+
+    assert client._sync_client.is_closed
+    assert client._async_client.is_closed
+    assert client.billing_key._sync_client.is_closed
+    assert client.billing_key._async_client.is_closed
+
+
+def test_root_client_context_manager_closes_sync_subclients():
+    with PortOneClient(secret="test") as client:
+        payment = client.payment
+        billing_key = payment.billing_key
+        assert not payment._sync_client.is_closed
+        assert not billing_key._sync_client.is_closed
+
+    try:
+        assert payment._sync_client.is_closed
+        assert billing_key._sync_client.is_closed
+    finally:
+        asyncio.run(client.aclose())
+
+
+def test_root_client_async_context_manager_closes_sync_and_async_subclients():
+    async def use_client():
+        async with PortOneClient(secret="test") as client:
+            payment = client.payment
+            billing_key = payment.billing_key
+            assert not payment._sync_client.is_closed
+            assert not payment._async_client.is_closed
+            assert not billing_key._sync_client.is_closed
+            assert not billing_key._async_client.is_closed
+        return payment, billing_key
+
+    payment, billing_key = asyncio.run(use_client())
+
+    assert payment._sync_client.is_closed
+    assert payment._async_client.is_closed
+    assert billing_key._sync_client.is_closed
+    assert billing_key._async_client.is_closed


### PR DESCRIPTION
## Summary

- Add generated `close()` / `aclose()` lifecycle methods to Python clients.
- Add sync and async context manager support for root and category clients.
- Delegate lifecycle calls through nested subclients so composed client trees are closed together.
- Cover the lifecycle behavior with focused no-network Python tests.

## Notes

`close()` closes the synchronous `httpx.Client` tree. `aclose()` closes both the synchronous and asynchronous `httpx` clients, matching async cleanup needs without forcing a sync method to drive an event loop.

## Verification

- `npx -y deno fmt --check python\project.ts`
- `npx -y deno check python\project.ts`
- `uv run pytest -q tests/test_client_lifecycle.py`
- `uv run pyright tests/test_client_lifecycle.py`
- `git diff --check`