### PR TITLE
fix(py): omit empty counterparty delete body

### DIFF
--- a/python/src/portone_server_sdk/_generated/b2b/counterparty/client.py
+++ b/python/src/portone_server_sdk/_generated/b2b/counterparty/client.py
@@ -757,7 +757,6 @@ class CounterpartyClient:
         query = []
         if test is not None:
             query.append(("test", test))
-        query.append(("requestBody", json.dumps(request_body)))
         response = self._sync_client.request(
             "DELETE",
             f"{self._base_url}/b2b/counterparties/{quote(counterparty_id, safe='')}",
@@ -846,7 +845,6 @@ class CounterpartyClient:
         query = []
         if test is not None:
             query.append(("test", test))
-        query.append(("requestBody", json.dumps(request_body)))
         response = await self._async_client.request(
             "DELETE",
             f"{self._base_url}/b2b/counterparties/{quote(counterparty_id, safe='')}",


### PR DESCRIPTION
generator fix was already in previous commit, but python gen was not run.

https://github.com/portone-io/server-sdk/commit/211dd565fe379c942ff5bf57fa951dbc5a0ab698#diff-bafcafab3d73903350cadbc9da0091efe2d80646b55c0cf9daa062a6c96945b4